### PR TITLE
Fixed a dependency colision when runing in docker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,12 +74,6 @@
          </exclusions>
       </dependency>
 
-      <!-- Add Log4j2 Dependency -->
-      <dependency>
-         <groupId>org.springframework.boot</groupId>
-         <artifactId>spring-boot-starter-log4j2</artifactId>
-      </dependency>
-
     <dependency>
 	<groupId>org.springframework.boot</groupId>
 	<artifactId>spring-boot-starter-actuator</artifactId>


### PR DESCRIPTION
Docker pulls its own version of log4j causing a dependency collision when the program is run in the container. To fix this error I've removed the log4j dependency in the pom.xml file